### PR TITLE
Fix crash on next opening of capture stream

### DIFF
--- a/src/PulsePcm.cpp
+++ b/src/PulsePcm.cpp
@@ -238,6 +238,10 @@ void PulsePcm::open(const PcmParams& params)
 	  << ", period: " << params.periodSize
 	  << ", buffer: " << params.bufferSize;
 
+	mReadData = nullptr;
+	mReadIndex = 0;
+	mReadLength = 0;
+
 	if (mStream)
 	{
 		throw Exception("PCM device " + mName + " already opened", PA_ERR_EXIST);

--- a/src/PulsePcm.hpp
+++ b/src/PulsePcm.hpp
@@ -262,6 +262,10 @@ private:
 	void startTimer();
 	void stopTimer();
 
+	void createStream();
+	void connectPlaybackStream(const char* deviceName);
+	void connectCaptureStream(const char* deviceName);
+
 	pa_sample_format_t convertPcmFormat(uint8_t format);
 };
 


### PR DESCRIPTION
After stream is closed read variables (mReadData, mReadIndex, mReadLength) keep their last values. These values are used on next stream open and cause segmentation fault. The fix is to set these variables to default values on stream open.