### PR TITLE
Fix generating core dump on segmentation fault

### DIFF
--- a/src/SndBackend.cpp
+++ b/src/SndBackend.cpp
@@ -368,12 +368,17 @@ void segmentationHandler(int sig)
 
 	backtrace_symbols_fd(array, size, STDERR_FILENO);
 
-	exit(1);
+	raise(sig);
 }
 
 void registerSignals()
 {
-	signal(SIGSEGV, segmentationHandler);
+	struct sigaction act {};
+
+	act.sa_handler = segmentationHandler;
+	act.sa_flags = SA_RESETHAND;
+
+	sigaction(SIGSEGV, &act, nullptr);
 }
 
 void waitSignals()


### PR DESCRIPTION
Due to default segfault handler is overridden to generate stack trace, core
dump is not generated. The fix is to restore default handler and send
SIGSEGV to itself.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>