### PR TITLE
Handle query HW params

### DIFF
--- a/src/AlsaPcm.hpp
+++ b/src/AlsaPcm.hpp
@@ -68,6 +68,13 @@ public:
 	~AlsaPcm();
 
 	/**
+	 * Queries the device for HW intervals and masks.
+	 * @req HW parameters that the frontend wants to set
+	 * @resp refined HW parameters that backend can support
+	 */
+	void queryHwRanges(SoundItf::PcmParamRanges& req, SoundItf::PcmParamRanges& resp) override;
+
+	/**
 	 * Opens the pcm device.
 	 * @param params pcm parameters
 	 */
@@ -134,7 +141,7 @@ private:
 
 	static PcmFormat sPcmFormat[];
 
-	snd_pcm_t *mHandle;
+	snd_pcm_t* mHandle;
 	std::string mDeviceName;
 	SoundItf::StreamType mType;
 	XenBackend::Timer mTimer;
@@ -146,10 +153,32 @@ private:
 	snd_pcm_uframes_t mFrameWritten;
 	snd_pcm_uframes_t mFrameUnderrun;
 
+	snd_pcm_t* mHwQueryHandle;
+	snd_pcm_hw_params_t* mHwQueryParams;
+
 	void setHwParams(const SoundItf::PcmParams& params);
 	void setSwParams();
 	void getTimeStamp();
 	snd_pcm_format_t convertPcmFormat(uint8_t format);
+
+	void queryOpen();
+	void queryClose();
+
+	void queryHwParamRate(snd_pcm_hw_params_t* hwParams,
+			      SoundItf::PcmParamRanges& req,
+			      SoundItf::PcmParamRanges& resp);
+	void queryHwParamBuffer(snd_pcm_hw_params_t* hwParams,
+				SoundItf::PcmParamRanges& req,
+				SoundItf::PcmParamRanges& resp);
+	void queryHwParamChannels(snd_pcm_hw_params_t* hwParams,
+				  SoundItf::PcmParamRanges& req,
+				  SoundItf::PcmParamRanges& resp);
+	void queryHwParamPeriod(snd_pcm_hw_params_t* hwParams,
+				SoundItf::PcmParamRanges& req,
+				SoundItf::PcmParamRanges& resp);
+	void queryHwParamFormats(snd_pcm_hw_params_t* hwParams,
+				 SoundItf::PcmParamRanges& req,
+				 SoundItf::PcmParamRanges& resp);
 };
 
 }

--- a/src/CommandHandler.hpp
+++ b/src/CommandHandler.hpp
@@ -79,11 +79,11 @@ public:
 	 * @param req
 	 * @return status
 	 */
-	int processCommand(const xensnd_req& req);
+	int processCommand(const xensnd_req& req, xensnd_resp& rsp);
 
 private:
 
-	typedef void(CommandHandler::*CommandFn)(const xensnd_req& req);
+	typedef void(CommandHandler::*CommandFn)(const xensnd_req& req, xensnd_resp& rsp);
 
 	static std::unordered_map<int, CommandFn> sCmdTable;
 
@@ -97,11 +97,12 @@ private:
 
 	void progressCbk(uint64_t bytes);
 
-	void open(const xensnd_req& req);
-	void close(const xensnd_req& req);
-	void read(const xensnd_req& req);
-	void write(const xensnd_req& req);
-	void trigger(const xensnd_req& req);
+	void open(const xensnd_req& req, xensnd_resp& rsp);
+	void close(const xensnd_req& req, xensnd_resp& rsp);
+	void read(const xensnd_req& req, xensnd_resp& rsp);
+	void write(const xensnd_req& req, xensnd_resp& rsp);
+	void trigger(const xensnd_req& req, xensnd_resp& rsp);
+	void queryHwParam(const xensnd_req& req, xensnd_resp& rsp);
 
 	void getBufferRefs(grant_ref_t startDirectory, uint32_t size, std::vector<grant_ref_t>& refs);
 };

--- a/src/PulsePcm.cpp
+++ b/src/PulsePcm.cpp
@@ -822,4 +822,9 @@ void PulsePcm::connectCaptureStream(const char* deviceName)
 	}
 }
 
+void PulsePcm::queryHwRanges(SoundItf::PcmParamRanges& req, SoundItf::PcmParamRanges& resp)
+{
+	throw Exception("NOT IMPLEMNTED " + mName, PA_ERR_UNKNOWN);
+}
+
 }

--- a/src/PulsePcm.hpp
+++ b/src/PulsePcm.hpp
@@ -153,6 +153,13 @@ public:
 	~PulsePcm();
 
 	/**
+	 * Queries the device for HW intervals and masks.
+	 * @req HW parameters that the frontend wants to set
+	 * @resp refined HW parameters that backend can support
+	 */
+	void queryHwRanges(SoundItf::PcmParamRanges& req, SoundItf::PcmParamRanges& resp) override;
+
+	/**
 	 * Opens the pcm device.
 	 * @param params pcm parameters
 	 */

--- a/src/SndBackend.cpp
+++ b/src/SndBackend.cpp
@@ -102,7 +102,7 @@ void StreamRingBuffer::processRequest(const xensnd_req& req)
 
 	rsp.id = req.id;
 	rsp.operation = req.operation;
-	rsp.status = mCommandHandler.processCommand(req);
+	rsp.status = mCommandHandler.processCommand(req, rsp);
 
 	sendResponse(rsp);
 }

--- a/src/SoundItf.hpp
+++ b/src/SoundItf.hpp
@@ -66,6 +66,35 @@ struct PcmParams
 };
 
 /***************************************************************************//**
+ * Describes pcm parameter ranges.
+ * @ingroup sound
+ ******************************************************************************/
+struct PcmParamRanges
+{
+	uint64_t formats;
+	struct
+	{
+		unsigned int min;
+		unsigned int max;
+	} rates;
+	struct
+	{
+		unsigned int min;
+		unsigned int max;
+	} channels;
+	struct
+	{
+		unsigned int min;
+		unsigned int max;
+	} buffer;
+	struct
+	{
+		unsigned int min;
+		unsigned int max;
+	} period;
+};
+
+/***************************************************************************//**
  * Provides sound functionality.
  * @ingroup sound
  ******************************************************************************/
@@ -74,6 +103,13 @@ class PcmDevice
 public:
 
 	virtual ~PcmDevice() {}
+
+	/**
+	 * Queries the device for HW intervals and masks.
+	 * @req HW parameters that the frontend wants to set
+	 * @resp refined HW parameters that backend can support
+	 */
+	virtual void queryHwRanges(PcmParamRanges& req, PcmParamRanges& resp) = 0;
 
 	/**
 	 * Opens the device.


### PR DESCRIPTION
In order to provide explicit stream parameter negotiation between
backend and frontend the following changes are introduced in the protocol:
add XENSND_OP_HW_PARAM_QUERY request to read/update
configuration space for the parameter given: request passes
desired parameter interval (mask) and the response to this request
returns min/max interval (mask) for the parameter to be used.

Parameters supported by this request/response:
 - format mask
 - sample rate interval
 - number of channels interval
 - buffer size, interval, frames
 - period size, interval, frames

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>