### PR TITLE
Handle query HW params for PulseAudio

### DIFF
--- a/src/PulsePcm.cpp
+++ b/src/PulsePcm.cpp
@@ -824,7 +824,7 @@ void PulsePcm::connectCaptureStream(const char* deviceName)
 
 void PulsePcm::queryHwRanges(SoundItf::PcmParamRanges& req, SoundItf::PcmParamRanges& resp)
 {
-	throw Exception("NOT IMPLEMNTED " + mName, PA_ERR_UNKNOWN);
+	resp = req;
 }
 
 }


### PR DESCRIPTION
HW parameters query handler implementation was missed for
PulseAudio. Implement this by returning the same parameters
as in the corresponding request as PulseAudio is much more
permissive than ALSA and can handle virtually any parameter
set.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>