### PR TITLE
Update frontend handlers to be aligned with new libxenbe interface

### DIFF
--- a/src/SndBackend.cpp
+++ b/src/SndBackend.cpp
@@ -111,11 +111,10 @@ void StreamRingBuffer::processRequest(const xensnd_req& req)
  * SndFrontendHandler
  ******************************************************************************/
 SndFrontendHandler::SndFrontendHandler(const string devName,
-									   domid_t beDomId, domid_t feDomId,
-									   uint16_t devId) :
-	FrontendHandlerBase("SndFrontend", devName, beDomId, feDomId, devId),
+									   domid_t domId, uint16_t devId) :
+	FrontendHandlerBase("SndFrontend", devName, domId, devId),
 #ifdef WITH_PULSE
-	mPulseMainloop("Dom" + to_string(feDomId) + ":" + to_string(devId)),
+	mPulseMainloop("Dom" + to_string(domId) + ":" + to_string(devId)),
 #endif
 	mLog("SndFrontend")
 {
@@ -350,7 +349,7 @@ string SndFrontendHandler::parsePropValue(string& input)
 void SndBackend::onNewFrontend(domid_t domId, uint16_t devId)
 {
 	addFrontendHandler(FrontendHandlerPtr(new SndFrontendHandler(
-			getDeviceName(), getDomId(), domId, devId)));
+			getDeviceName(), domId, devId)));
 }
 
 /*******************************************************************************

--- a/src/SndBackend.hpp
+++ b/src/SndBackend.hpp
@@ -82,12 +82,11 @@ public:
 
 	/**
 	 * @param devName device name
-	 * @param beDomId backend domain id
-	 * @param feDomId frontend domain id
+	 * @param domId frontend domain id
 	 * @param devId   device id
 	 */
 	SndFrontendHandler(const std::string devName,
-					   domid_t beDomId, domid_t feDomId, uint16_t devId);
+					   domid_t domId, uint16_t devId);
 
 protected:
 


### PR DESCRIPTION
BE dom id parameter was removed from FrontendHandlerBase. Update snd
frontend handlers accordingly. This commit should be merged once https://github.com/xen-troops/libxenbe/pull/47 is merged.