### PR TITLE
Device or resouce busy with compiling option `-DWITH_ALSA=ON -DWITH_PULSE=OFF`

### DIFF
--- a/src/AlsaPcm.hpp
+++ b/src/AlsaPcm.hpp
@@ -147,6 +147,8 @@ private:
 	XenBackend::Timer mTimer;
 	std::chrono::milliseconds mTimerPeriodMs;
 	XenBackend::Log mLog;
+	uint32_t dev_status;
+	uint32_t query_status;
 
 	SoundItf::PcmParams mParams;
 


### PR DESCRIPTION
#Hi,
snd_be outputs an error message as below when I create a virtual PCM card for DomainU system (ubuntu or android) by xl command (xen project version is 4.15.1). 
**Error message:**
**_09.02.22 06.02:19.661 | CommandHandler | ERR - Can't open audio device hw:1,0 (Device or resource busy)_**
![image](https://user-images.githubusercontent.com/35024004/153144422-293f1bf3-ff8d-4b03-8e37-028248185cb0.png)

snd_be configured with compiling option: `-DWITH_ALSA=ON -DWITH_PULSE=OFF`, and my vsnd configuration as follow:
```
vsnd = [
               [ 'CARD, buffer-size=262144, short-name=VCard, long-name=Virtual sound card',
                        'PCM, name=vsnd', 'STREAM, unique-id=alsa<hw:1;0>, type=p' , 'STREAM, unique-id=alsa<hw:1;0>, type=c'
               ]
]
```

To solve this problem, I have to modify the snd_be code. This issue may be caused by command conflict, for example, the backend receive a 'queryOpen' command from frontend, and then it will create a handle with device hw:1,0, before the handle released (that is before backend receive the 'queryClose' command), backend receive the ‘open’ command, so the audio device hw:1,0 can not opened at this time. 
Thanks a lot!
